### PR TITLE
Cover ping locations in the link-location test

### DIFF
--- a/tests/LinkExtractorTest.php
+++ b/tests/LinkExtractorTest.php
@@ -86,7 +86,7 @@ class LinkExtractorTest extends \PHPUnit\Framework\TestCase
     {
         $defaults = (new \ReflectionClass(LinkExtractor::class))->getDefaultProperties();
         $locations = [];
-        foreach (['urlAttributes' => false, 'nonEmptyUrlAttributes' => true] as $property => $needsValue) {
+        foreach (['urlAttributes' => false, 'nonEmptyUrlAttributes' => true, 'spaceSeparatedUrlAttributes' => true] as $property => $needsValue) {
             foreach ($defaults[$property] as $attribute => $elements) {
                 foreach ($elements as $element) {
                     $locations["{$element}[@{$attribute}]"] = [$attribute, $element, $needsValue];


### PR DESCRIPTION
I missed adding the new `spaceSeparatedUrlAttributes` to the test that checks all possible attributes have matching fixtures. Does not break anything, we do have tests in place, it is just to stop future regressions.