### PR TITLE
Add support for `\Dom\Node` on PHP 8.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $extractor = new \Zegnat\LinkExtractor\LinkExtractor($dom, 'http://example.com/i
 ## Supported PHP versions
 
 This library requires PHP 7.0 or newer and is tested against PHP 7.0, 7.1, 
-7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3 and 8.4.
+7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 and 8.5.
 
 From PHP 8.4 onwards it accepts both `\DOMNode` and `\Dom\Node`.
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ $ composer require zegnat/linkextractor
 ## Usage
 
 ``` php
-// Parse an HTML file into a DOMDocument somehow, e.g.:
-$dom = new \Zegnat\Html\DOMDocument();
+// Parse the HTML into a DOMDocument:
+$dom = new \DOMDocument();
 $dom->loadHTML(file_get_contents('http://example.com/index.html'));
-// Now initiate the extractor:
+// Initiate the extractor with the document and its URL:
 $extractor = new \Zegnat\LinkExtractor\LinkExtractor($dom, 'http://example.com/index.html');
 var_dump(
     $extractor->linksTo('https://github.com/'),
@@ -64,10 +64,22 @@ bool(true)
 */
 ```
 
+On PHP 8.4 and newer you can instead pass a document parsed with the new 
+`\Dom\HTMLDocument` API and its standards-compliant HTML parser:
+
+``` php
+$dom = \Dom\HTMLDocument::createFromString(
+    file_get_contents('http://example.com/index.html')
+);
+$extractor = new \Zegnat\LinkExtractor\LinkExtractor($dom, 'http://example.com/index.html');
+```
+
 ## Supported PHP versions
 
 This library requires PHP 7.0 or newer and is tested against PHP 7.0, 7.1, 
 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3 and 8.4.
+
+From PHP 8.4 onwards it accepts both `\DOMNode` and `\Dom\Node`.
 
 ## Testing
 

--- a/castor.php
+++ b/castor.php
@@ -8,7 +8,7 @@ use function Castor\context;
 use function Castor\io;
 use function Castor\run;
 
-const PHP_VERSIONS = ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4'];
+const PHP_VERSIONS = ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5'];
 const DEFAULT_PHP = '8.4';
 
 #[AsTask(description: 'Run the test suite on a single PHP version')]

--- a/src/LinkExtractor.php
+++ b/src/LinkExtractor.php
@@ -60,10 +60,10 @@ class LinkExtractor
      **/
     private $htmlSpaceCharacters = ' \t\n\f\r';
 
-    /** @var DOMNode $root */
+    /** @var \DOMNode|\Dom\Node $root */
     private $root;
 
-    /** @var XPath $root */
+    /** @var \DOMXPath|\Dom\XPath $xpath */
     private $xpath;
 
     /** @var Uri $baseUrl */
@@ -112,23 +112,29 @@ class LinkExtractor
      * Even if a sub element of the document is supplied, it will still apply any BASE elements from th entire document
      * for the purpose of resolving relative URLs.
      *
-     * @param \DOMNode $root    Any DOMNode, including the entire DOMDocument, to use as root.
-     * @param string   $baseUrl The URL for the document, to resolve relative URLs against.
+     * @param \DOMNode|\Dom\Node $root    Any node, including a whole document, to use as root.
+     * @param string             $baseUrl The URL for the document, to resolve relative URLs against.
      *
+     * @throws \TypeError If $root is neither a \DOMNode nor a \Dom\Node.
      * @throws \InvalidArgumentException If the BASE element’s HREF could not be parsed as a valid URI.
      *
      * @api
      **/
-    public function __construct(\DOMNode $root, string $baseUrl = '')
+    public function __construct($root, string $baseUrl = '')
     {
+        $modernParser = \class_exists('\\Dom\\Node') && $root instanceof \Dom\Node;
+        if (!$root instanceof \DOMNode && !$modernParser) {
+            throw new \TypeError('$root must be a \\DOMNode or a \\Dom\\Node.');
+        }
         $this->root = $root;
-        $ownerDocument = $root instanceof \DOMDocument ? $root : $root->ownerDocument;
-        $this->xpath = new \DOMXPath($ownerDocument);
+        $ownerDocument = $root->ownerDocument ?? $root;
+        $this->xpath = $modernParser ? new \Dom\XPath($ownerDocument) : new \DOMXPath($ownerDocument);
         $baseUrl = new Uri($baseUrl);
 
         // Update the base URL in case a BASE element was provided.
         // We are not going to care about the validity of the location of the BASE element.
-        $base = $this->xpath->query('//base[@href]', $root);
+        // Match on local-name() because the modern parser adds a namespace.
+        $base = $this->xpath->query("//*[local-name()='base'][@href]", $root);
         if ($base !== false && $base->length > 0) {
             $baseElementUrl = new Uri($this->htmlStripWhitespace($base->item(0)->getAttribute('href')));
             $baseUrl = UriResolver::resolve($baseUrl, $baseElementUrl);
@@ -168,7 +174,7 @@ class LinkExtractor
         foreach ($urlAttributes as $urlAttribute) {
             $name = $urlAttribute->name;
             $url = $this->htmlStripWhitespace($urlAttribute->value);
-            $element = $urlAttribute->parentNode->tagName;
+            $element = \strtolower($urlAttribute->parentNode->tagName);
             if (
                 \array_key_exists($name, $this->urlAttributes)
                 && \in_array($element, $this->urlAttributes[$name])

--- a/src/LinkExtractor.php
+++ b/src/LinkExtractor.php
@@ -6,8 +6,6 @@
  * 1. what constitutes a link between an HTML document and another resource, and
  * 2. how to supply them in a useful (resolved) format.
  *
- * PHP version 7
- *
  * @author    Martijn van der Ven <martijn@vanderven.se>
  * @copyright 2017 Martijn van der Ven
  * @license   BSD Zero Clause License
@@ -53,10 +51,10 @@ class LinkExtractor
     ];
 
     /**
-     * Characters identified as space characters per the HTML5 spec.
+     * Characters identified as ASCII whitespace by the Infra Standard.
      *
      * @var string $htmlSpaceCharacters
-     * @see https://www.w3.org/TR/html5/infrastructure.html#space-character
+     * @see https://infra.spec.whatwg.org/#ascii-whitespace
      **/
     private $htmlSpaceCharacters = ' \t\n\f\r';
 
@@ -73,13 +71,13 @@ class LinkExtractor
     private $extracted = null;
 
     /**
-     * Strip the leading and trailing whitespace per the HTML5 spec.
+     * Strip the leading and trailing whitespace per the Infra Standard.
      *
      * @param string $string
      *
      * @return string
      *
-     * @see https://www.w3.org/TR/html5/infrastructure.html#strip-leading-and-trailing-whitespace
+     * @see https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace
      **/
     private function htmlStripWhitespace(string $string): string
     {

--- a/tests/LinkExtractorTest.php
+++ b/tests/LinkExtractorTest.php
@@ -46,6 +46,19 @@ class LinkExtractorTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($extractor->linksTo(':'));
     }
 
+    public function testLinksToModern()
+    {
+        if (!class_exists('\\Dom\\HTMLDocument')) {
+            $this->markTestSkipped('Modern \Dom\HTMLDocument not available.');
+        }
+        $dom = \Dom\HTMLDocument::createFromFile(__DIR__ . '/files/example.com-index.html', LIBXML_NOERROR);
+        $extractor = new LinkExtractor($dom, 'http://example.com/index.html');
+        $extractor->extract();
+        $this->assertTrue($extractor->linksTo('http://www.iana.org/domains/example'));
+        $this->assertFalse($extractor->linksTo('https://github.com/'));
+        $this->assertFalse($extractor->linksTo(':'));
+    }
+
     /**
      * @dataProvider linkLocationProvider
      */

--- a/tests/LinkExtractorTest.php
+++ b/tests/LinkExtractorTest.php
@@ -16,6 +16,12 @@ namespace Zegnat\LinkExtractor;
 
 class LinkExtractorTest extends \PHPUnit\Framework\TestCase
 {
+    public function testConstructorRejectsUnsupportedRoot()
+    {
+        $this->expectException(\TypeError::class);
+        new LinkExtractor('not a DOM node');
+    }
+
     /**
      * @dataProvider filesProvider
      */

--- a/tests/LinkExtractorTest.php
+++ b/tests/LinkExtractorTest.php
@@ -2,8 +2,6 @@
 /**
  * Testing if LinkExtractor extracts links.
  *
- * PHP version 7
- *
  * @author    Martijn van der Ven <martijn@vanderven.se>
  * @author    Christian Weiske <cweiske@cweiske.de>
  * @copyright 2017 Martijn van der Ven and authors
@@ -21,10 +19,14 @@ class LinkExtractorTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider filesProvider
      */
-    public function testExtract($dom, $fileUrl, $expectedUrls)
+    public function testExtract($dom, $modernDom, $fileUrl, $expectedUrls)
     {
         $extractor = new LinkExtractor($dom, $fileUrl);
-        $this->assertEquals($expectedUrls, $extractor->extract());
+        $this->assertEquals($expectedUrls, $extractor->extract(), '\DOMDocument');
+        if ($modernDom !== null) {
+            $extractor = new LinkExtractor($modernDom, $fileUrl);
+            $this->assertEquals($expectedUrls, $extractor->extract(), '\Dom\HTMLDocument');
+        }
     }
 
     public function testLinksTo()
@@ -57,6 +59,9 @@ class LinkExtractorTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($covered, "No fixture exercises {$element}[@{$attribute}].");
     }
 
+    /**
+     * @return array<int, array{0: \DOMDocument, 1: ?\Dom\HTMLDocument, 2: string, 3: string[]}>
+     */
     public static function filesProvider(): array
     {
         static $data;
@@ -73,8 +78,12 @@ class LinkExtractorTest extends \PHPUnit\Framework\TestCase
             $urlfile = substr($htmlfile, 0, -5) . '.url';
             $dom = new \DOMDocument();
             $dom->loadHTMLFile($htmlfile, LIBXML_NOERROR | LIBXML_NOWARNING);
+            $modern = class_exists('\\Dom\\HTMLDocument')
+                ? \Dom\HTMLDocument::createFromFile($htmlfile, LIBXML_NOERROR)
+                : null;
             $data[] = [
                 $dom,
+                $modern,
                 trim(file_get_contents($urlfile)),
                 file($urlsfile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES)
             ];


### PR DESCRIPTION
Broaden our accepted DOM input to also support the new HTML parser shipped in PHP 8.4+.

This also makes sure we are testing PHP 8.5, which I seemed to miss before.